### PR TITLE
Unify usage of StrongType::get_value() and use template function for type conversion

### DIFF
--- a/examples/simple_spi_rw_example/main/simple_spi_rw_example.cpp
+++ b/examples/simple_spi_rw_example/main/simple_spi_rw_example.cpp
@@ -32,7 +32,7 @@ extern "C" void app_main(void)
                 MISO(26),
                 SCLK(27));
 
-        shared_ptr<SPIDevice> spi_dev = master.create_dev(CS(NSS.get_num()), Frequency::MHz(1));
+        shared_ptr<SPIDevice> spi_dev = master.create_dev(CS(NSS.get_value()), Frequency::MHz(1));
 
         vector<uint8_t> write_data = {MPU9250_WHO_AM_I_REG_ADDR | READ_FLAG, 0x00};
         vector<uint8_t> result = spi_dev->transfer(write_data).get();

--- a/gpio_cxx.cpp
+++ b/gpio_cxx.cpp
@@ -31,11 +31,6 @@ constexpr std::array<uint32_t, 0> INVALID_GPIOS = {};
 #error "No GPIOs defined for the current target"
 #endif
 
-gpio_num_t gpio_to_driver_type(const GPIONum &gpio_num)
-{
-    return static_cast<gpio_num_t>(gpio_num.get_num());
-}
-
 }
 
 GPIOException::GPIOException(esp_err_t error) : ESPException(error) { }
@@ -117,55 +112,55 @@ GPIODriveStrength GPIODriveStrength::STRONGEST()
 
 GPIOBase::GPIOBase(GPIONum num) : gpio_num(num)
 {
-    GPIO_CHECK_THROW(gpio_reset_pin(gpio_to_driver_type(gpio_num)));
+    GPIO_CHECK_THROW(gpio_reset_pin(gpio_num.get_value<gpio_num_t>()));
 }
 
 void GPIOBase::hold_en()
 {
-    GPIO_CHECK_THROW(gpio_hold_en(gpio_to_driver_type(gpio_num)));
+    GPIO_CHECK_THROW(gpio_hold_en(gpio_num.get_value<gpio_num_t>()));
 }
 
 void GPIOBase::hold_dis()
 {
-    GPIO_CHECK_THROW(gpio_hold_dis(gpio_to_driver_type(gpio_num)));
+    GPIO_CHECK_THROW(gpio_hold_dis(gpio_num.get_value<gpio_num_t>()));
 }
 
 void GPIOBase::set_drive_strength(GPIODriveStrength strength)
 {
-    GPIO_CHECK_THROW(gpio_set_drive_capability(gpio_to_driver_type(gpio_num),
-            static_cast<gpio_drive_cap_t>(strength.get_strength())));
+    GPIO_CHECK_THROW(gpio_set_drive_capability(gpio_num.get_value<gpio_num_t>(),
+                                               strength.get_value<gpio_drive_cap_t>()));
 }
 
 GPIO_Output::GPIO_Output(GPIONum num) : GPIOBase(num)
 {
-    GPIO_CHECK_THROW(gpio_set_direction(gpio_to_driver_type(gpio_num), GPIO_MODE_OUTPUT));
+    GPIO_CHECK_THROW(gpio_set_direction(gpio_num.get_value<gpio_num_t>(), GPIO_MODE_OUTPUT));
 }
 
 void GPIO_Output::set_high()
 {
-    GPIO_CHECK_THROW(gpio_set_level(gpio_to_driver_type(gpio_num), 1));
+    GPIO_CHECK_THROW(gpio_set_level(gpio_num.get_value<gpio_num_t>(), 1));
 }
 
 void GPIO_Output::set_low()
 {
-    GPIO_CHECK_THROW(gpio_set_level(gpio_to_driver_type(gpio_num), 0));
+    GPIO_CHECK_THROW(gpio_set_level(gpio_num.get_value<gpio_num_t>(), 0));
 }
 
 GPIODriveStrength GPIOBase::get_drive_strength()
 {
     gpio_drive_cap_t strength;
-    GPIO_CHECK_THROW(gpio_get_drive_capability(gpio_to_driver_type(gpio_num), &strength));
+    GPIO_CHECK_THROW(gpio_get_drive_capability(gpio_num.get_value<gpio_num_t>(), &strength));
     return GPIODriveStrength(static_cast<uint32_t>(strength));
 }
 
 GPIOInput::GPIOInput(GPIONum num) : GPIOBase(num)
 {
-    GPIO_CHECK_THROW(gpio_set_direction(gpio_to_driver_type(gpio_num), GPIO_MODE_INPUT));
+    GPIO_CHECK_THROW(gpio_set_direction(gpio_num.get_value<gpio_num_t>(), GPIO_MODE_INPUT));
 }
 
 GPIOLevel GPIOInput::get_level() const noexcept
 {
-    int level = gpio_get_level(gpio_to_driver_type(gpio_num));
+    int level = gpio_get_level(gpio_num.get_value<gpio_num_t>());
     if (level) {
         return GPIOLevel::HIGH;
     } else {
@@ -175,34 +170,34 @@ GPIOLevel GPIOInput::get_level() const noexcept
 
 void GPIOInput::set_pull_mode(GPIOPullMode mode)
 {
-    GPIO_CHECK_THROW(gpio_set_pull_mode(gpio_to_driver_type(gpio_num),
-            static_cast<gpio_pull_mode_t>(mode.get_pull_mode())));
+    GPIO_CHECK_THROW(gpio_set_pull_mode(gpio_num.get_value<gpio_num_t>(),
+                                        mode.get_value<gpio_pull_mode_t>()));
 }
 
 void GPIOInput::wakeup_enable(GPIOWakeupIntrType interrupt_type)
 {
-    GPIO_CHECK_THROW(gpio_wakeup_enable(gpio_to_driver_type(gpio_num),
-            static_cast<gpio_int_type_t>(interrupt_type.get_level())));
+    GPIO_CHECK_THROW(gpio_wakeup_enable(gpio_num.get_value<gpio_num_t>(),
+                                        interrupt_type.get_value<gpio_int_type_t>()));
 }
 
 void GPIOInput::wakeup_disable()
 {
-    GPIO_CHECK_THROW(gpio_wakeup_disable(gpio_to_driver_type(gpio_num)));
+    GPIO_CHECK_THROW(gpio_wakeup_disable(gpio_num.get_value<gpio_num_t>()));
 }
 
 GPIO_OpenDrain::GPIO_OpenDrain(GPIONum num) : GPIOInput(num)
 {
-    GPIO_CHECK_THROW(gpio_set_direction(gpio_to_driver_type(gpio_num), GPIO_MODE_INPUT_OUTPUT_OD));
+    GPIO_CHECK_THROW(gpio_set_direction(gpio_num.get_value<gpio_num_t>(), GPIO_MODE_INPUT_OUTPUT_OD));
 }
 
 void GPIO_OpenDrain::set_floating()
 {
-    GPIO_CHECK_THROW(gpio_set_level(gpio_to_driver_type(gpio_num), 1));
+    GPIO_CHECK_THROW(gpio_set_level(gpio_num.get_value<gpio_num_t>(), 1));
 }
 
 void GPIO_OpenDrain::set_low()
 {
-    GPIO_CHECK_THROW(gpio_set_level(gpio_to_driver_type(gpio_num), 0));
+    GPIO_CHECK_THROW(gpio_set_level(gpio_num.get_value<gpio_num_t>(), 0));
 }
 
 }

--- a/host_test/fixtures/test_fixtures.hpp
+++ b/host_test/fixtures/test_fixtures.hpp
@@ -86,8 +86,8 @@ struct GPIOFixture : public CMockFixture {
     GPIOFixture(idf::GPIONum gpio_num = idf::GPIONum(18), gpio_mode_t mode = GPIO_MODE_OUTPUT)
         : CMockFixture(), num(gpio_num)
     {
-        gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(num.get_num()), ESP_OK);
-        gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(num.get_num()), mode, ESP_OK);
+        gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(num.get_value()), ESP_OK);
+        gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(num.get_value()), mode, ESP_OK);
     }
 
     idf::GPIONum num;

--- a/host_test/gpio/main/gpio_cxx_test.cpp
+++ b/host_test/gpio/main/gpio_cxx_test.cpp
@@ -59,24 +59,24 @@ TEST_CASE("drive strength out of range")
 
 TEST_CASE("drive strength as expected")
 {
-    CHECK(GPIODriveStrength::DEFAULT().get_strength() == GPIO_DRIVE_CAP_2);
-    CHECK(GPIODriveStrength::WEAK().get_strength() == GPIO_DRIVE_CAP_0);
-    CHECK(GPIODriveStrength::LESS_WEAK().get_strength() == GPIO_DRIVE_CAP_1);
-    CHECK(GPIODriveStrength::MEDIUM().get_strength() == GPIO_DRIVE_CAP_2);
-    CHECK(GPIODriveStrength::STRONGEST().get_strength() == GPIO_DRIVE_CAP_3);
+    CHECK(GPIODriveStrength::DEFAULT().get_value() == GPIO_DRIVE_CAP_2);
+    CHECK(GPIODriveStrength::WEAK().get_value() == GPIO_DRIVE_CAP_0);
+    CHECK(GPIODriveStrength::LESS_WEAK().get_value() == GPIO_DRIVE_CAP_1);
+    CHECK(GPIODriveStrength::MEDIUM().get_value() == GPIO_DRIVE_CAP_2);
+    CHECK(GPIODriveStrength::STRONGEST().get_value() == GPIO_DRIVE_CAP_3);
 }
 
 TEST_CASE("pull mode create functions work as expected")
 {
-    CHECK(GPIOPullMode::FLOATING().get_pull_mode() == 3);
-    CHECK(GPIOPullMode::PULLUP().get_pull_mode() == 0);
-    CHECK(GPIOPullMode::PULLDOWN().get_pull_mode() == 1);
+    CHECK(GPIOPullMode::FLOATING().get_value() == 3);
+    CHECK(GPIOPullMode::PULLUP().get_value() == 0);
+    CHECK(GPIOPullMode::PULLDOWN().get_value() == 1);
 }
 
 TEST_CASE("GPIOIntrType create functions work as expected")
 {
-    CHECK(GPIOWakeupIntrType::LOW_LEVEL().get_level() == GPIO_INTR_LOW_LEVEL);
-    CHECK(GPIOWakeupIntrType::HIGH_LEVEL().get_level() == GPIO_INTR_HIGH_LEVEL);
+    CHECK(GPIOWakeupIntrType::LOW_LEVEL().get_value() == GPIO_INTR_LOW_LEVEL);
+    CHECK(GPIOWakeupIntrType::HIGH_LEVEL().get_value() == GPIO_INTR_HIGH_LEVEL);
 }
 
 TEST_CASE("output resetting pin fails")
@@ -103,8 +103,8 @@ TEST_CASE("output setting direction fails")
 TEST_CASE("output constructor sets correct arguments")
 {
     CMOCK_SETUP();
-    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()), ESP_OK);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()), GPIO_MODE_OUTPUT, ESP_OK);
+    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()), ESP_OK);
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()), GPIO_MODE_OUTPUT, ESP_OK);
 
     GPIO_Output gpio(VALID_GPIO);
 
@@ -114,7 +114,7 @@ TEST_CASE("output constructor sets correct arguments")
 TEST_CASE("output set high fails")
 {
     GPIOFixture fix;
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 1, ESP_FAIL);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 1, ESP_FAIL);
 
     GPIO_Output gpio(fix.num);
 
@@ -124,7 +124,7 @@ TEST_CASE("output set high fails")
 TEST_CASE("output set high success")
 {
     GPIOFixture fix;
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 1, ESP_OK);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 1, ESP_OK);
 
     GPIO_Output gpio(fix.num);
 
@@ -134,7 +134,7 @@ TEST_CASE("output set high success")
 TEST_CASE("output set low fails")
 {
     GPIOFixture fix;
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 0, ESP_FAIL);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 0, ESP_FAIL);
 
     GPIO_Output gpio(fix.num);
 
@@ -144,7 +144,7 @@ TEST_CASE("output set low fails")
 TEST_CASE("output set low success")
 {
     GPIOFixture fix;
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 0, ESP_OK);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 0, ESP_OK);
 
     GPIO_Output gpio(fix.num);
 
@@ -154,7 +154,7 @@ TEST_CASE("output set low success")
 TEST_CASE("output set drive strength")
 {
     GPIOFixture fix(VALID_GPIO);
-    gpio_set_drive_capability_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_DRIVE_CAP_0, ESP_OK);
+    gpio_set_drive_capability_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_DRIVE_CAP_0, ESP_OK);
 
     GPIO_Output gpio(fix.num);
 
@@ -187,8 +187,8 @@ TEST_CASE("GPIOInput setting direction fails")
 TEST_CASE("constructor sets correct arguments")
 {
     CMOCK_SETUP();
-    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()), ESP_OK);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()), GPIO_MODE_INPUT, ESP_OK);
+    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()), ESP_OK);
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()), GPIO_MODE_INPUT, ESP_OK);
 
     GPIOInput gpio(VALID_GPIO);
 
@@ -198,7 +198,7 @@ TEST_CASE("constructor sets correct arguments")
 TEST_CASE("get level low")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_get_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 0);
+    gpio_get_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 0);
 
     GPIOInput gpio(fix.num);
 
@@ -208,7 +208,7 @@ TEST_CASE("get level low")
 TEST_CASE("get level high")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_get_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 1);
+    gpio_get_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 1);
 
     GPIOInput gpio(fix.num);
 
@@ -218,7 +218,7 @@ TEST_CASE("get level high")
 TEST_CASE("set pull mode fails")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_FLOATING, ESP_FAIL);
+    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_FLOATING, ESP_FAIL);
 
     GPIOInput gpio(fix.num);
 
@@ -228,7 +228,7 @@ TEST_CASE("set pull mode fails")
 TEST_CASE("GPIOInput set pull mode floating")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_FLOATING, ESP_OK);
+    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_FLOATING, ESP_OK);
 
     GPIOInput gpio(fix.num);
 
@@ -238,7 +238,7 @@ TEST_CASE("GPIOInput set pull mode floating")
 TEST_CASE("GPIOInput set pull mode pullup")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_PULLUP_ONLY, ESP_OK);
+    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_PULLUP_ONLY, ESP_OK);
 
     GPIOInput gpio(fix.num);
 
@@ -248,7 +248,7 @@ TEST_CASE("GPIOInput set pull mode pullup")
 TEST_CASE("GPIOInput set pull mode pulldown")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_PULLDOWN_ONLY, ESP_OK);
+    gpio_set_pull_mode_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_PULLDOWN_ONLY, ESP_OK);
 
     GPIOInput gpio(fix.num);
 
@@ -258,7 +258,7 @@ TEST_CASE("GPIOInput set pull mode pulldown")
 TEST_CASE("GPIOInput wake up enable fails")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_wakeup_enable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_INTR_LOW_LEVEL, ESP_FAIL);
+    gpio_wakeup_enable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_INTR_LOW_LEVEL, ESP_FAIL);
 
     GPIOInput gpio(fix.num);
 
@@ -268,7 +268,7 @@ TEST_CASE("GPIOInput wake up enable fails")
 TEST_CASE("GPIOInput wake up enable high int")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_wakeup_enable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_INTR_HIGH_LEVEL, ESP_OK);
+    gpio_wakeup_enable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_INTR_HIGH_LEVEL, ESP_OK);
 
     GPIOInput gpio(fix.num);
 
@@ -278,7 +278,7 @@ TEST_CASE("GPIOInput wake up enable high int")
 TEST_CASE("GPIOInput wake up disable fails")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_wakeup_disable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), ESP_FAIL);
+    gpio_wakeup_disable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), ESP_FAIL);
 
     GPIOInput gpio(fix.num);
 
@@ -288,7 +288,7 @@ TEST_CASE("GPIOInput wake up disable fails")
 TEST_CASE("GPIOInput wake up disable high int")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_wakeup_disable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), ESP_OK);
+    gpio_wakeup_disable_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), ESP_OK);
 
     GPIOInput gpio(fix.num);
 
@@ -309,11 +309,11 @@ TEST_CASE("GPIO_OpenDrain setting direction fails")
 TEST_CASE("GPIO_OpenDrain constructor sets correct arguments")
 {
     CMOCK_SETUP();
-    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()), ESP_OK);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_reset_pin_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()), ESP_OK);
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT,
             ESP_OK);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
 
@@ -325,10 +325,10 @@ TEST_CASE("GPIO_OpenDrain constructor sets correct arguments")
 TEST_CASE("GPIO_OpenDrain set floating fails")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 1, ESP_FAIL);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 1, ESP_FAIL);
 
     GPIO_OpenDrain gpio(fix.num);
 
@@ -338,10 +338,10 @@ TEST_CASE("GPIO_OpenDrain set floating fails")
 TEST_CASE("GPIO_OpenDrain set floating success")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 1, ESP_OK);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 1, ESP_OK);
 
     GPIO_OpenDrain gpio(fix.num);
 
@@ -351,10 +351,10 @@ TEST_CASE("GPIO_OpenDrain set floating success")
 TEST_CASE("GPIO_OpenDrain set low fails")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 0, ESP_FAIL);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 0, ESP_FAIL);
 
     GPIO_OpenDrain gpio(fix.num);
 
@@ -364,10 +364,10 @@ TEST_CASE("GPIO_OpenDrain set low fails")
 TEST_CASE("GPIO_OpenDrain set low success")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
-    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), 0, ESP_OK);
+    gpio_set_level_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), 0, ESP_OK);
 
     GPIO_OpenDrain gpio(fix.num);
 
@@ -377,11 +377,11 @@ TEST_CASE("GPIO_OpenDrain set low success")
 TEST_CASE("GPIO_OpenDrain set drive strength")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
 
-    gpio_set_drive_capability_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_num()), GPIO_DRIVE_CAP_0, ESP_OK);
+    gpio_set_drive_capability_ExpectAndReturn(static_cast<gpio_num_t>(fix.num.get_value()), GPIO_DRIVE_CAP_0, ESP_OK);
     GPIO_OpenDrain gpio(fix.num);
 
     gpio.set_drive_strength(GPIODriveStrength::WEAK());
@@ -390,7 +390,7 @@ TEST_CASE("GPIO_OpenDrain set drive strength")
 TEST_CASE("GPIO_OpenDrain get drive strength")
 {
     GPIOFixture fix(VALID_GPIO, GPIO_MODE_INPUT);
-    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_num()),
+    gpio_set_direction_ExpectAndReturn(static_cast<gpio_num_t>(VALID_GPIO.get_value()),
             GPIO_MODE_INPUT_OUTPUT_OD,
             ESP_OK);
     gpio_drive_cap_t drive_strength = GPIO_DRIVE_CAP_3;

--- a/host_test/i2c/main/i2c_cxx_test.cpp
+++ b/host_test/i2c/main/i2c_cxx_test.cpp
@@ -37,7 +37,7 @@ using namespace idf;
 TEST_CASE("I2CNumber")
 {
     CMockFixture fix;
-    CHECK(I2CNumber::I2C0().get_num() == 0);
+    CHECK(I2CNumber::I2C0().get_value() == 0);
 }
 
 TEST_CASE("I2CAddr")
@@ -49,7 +49,7 @@ TEST_CASE("I2CAddr")
     CHECK_THROWS_AS(I2CAddress(128), I2CException&);
 
     I2CAddress addr(47);
-    CHECK(addr.get_addr() == 47);
+    CHECK(addr.get_value() == 47);
 }
 
 TEST_CASE("I2CMaster parameter configuration fails")

--- a/host_test/spi/main/spi_cxx_test.cpp
+++ b/host_test/spi/main/spi_cxx_test.cpp
@@ -44,17 +44,17 @@ TEST_CASE("SPI gpio numbers work correctly")
 {
     GPIONum gpio_num_0(19);
     MOSI mosi_0(18);
-    MOSI mosi_1(gpio_num_0.get_num());
+    MOSI mosi_1(gpio_num_0.get_value());
     MOSI mosi_2(mosi_0);
     CHECK(mosi_0 != mosi_1);
     CHECK(mosi_2 == mosi_0);
-    CHECK(mosi_2.get_num() == 18u);
+    CHECK(mosi_2.get_value() == 18u);
 }
 
 TEST_CASE("SPI_DMAConfig valid")
 {
-    CHECK(SPI_DMAConfig::AUTO().get_num() == spi_common_dma_t::SPI_DMA_CH_AUTO);
-    CHECK(SPI_DMAConfig::DISABLED().get_num() == spi_common_dma_t::SPI_DMA_DISABLED);
+    CHECK(SPI_DMAConfig::AUTO().get_value() == spi_common_dma_t::SPI_DMA_CH_AUTO);
+    CHECK(SPI_DMAConfig::DISABLED().get_value() == spi_common_dma_t::SPI_DMA_DISABLED);
 }
 
 TEST_CASE("SPINum invalid argument")

--- a/include/gpio_cxx.hpp
+++ b/include/gpio_cxx.hpp
@@ -56,11 +56,6 @@ public:
 
     using StrongValueComparable<uint32_t>::operator==;
     using StrongValueComparable<uint32_t>::operator!=;
-
-    /**
-     * Retrieves the valid numerical representation of the GPIO number.
-     */
-    uint32_t get_num() const { return get_value(); };
 };
 
 /**
@@ -116,11 +111,6 @@ public:
 
     using StrongValueComparable<uint32_t>::operator==;
     using StrongValueComparable<uint32_t>::operator!=;
-
-    /**
-     * Retrieves the valid numerical representation of the pull mode.
-     */
-    uint32_t get_pull_mode() const { return get_value(); };
 };
 
 /**
@@ -142,11 +132,6 @@ private:
 public:
     static GPIOWakeupIntrType LOW_LEVEL();
     static GPIOWakeupIntrType HIGH_LEVEL();
-
-    /**
-     * Retrieves the valid numerical representation of the pull mode.
-     */
-    uint32_t get_level() const noexcept { return get_value(); };
 };
 
 /**
@@ -209,12 +194,6 @@ public:
 
     using StrongValueComparable<uint32_t>::operator==;
     using StrongValueComparable<uint32_t>::operator!=;
-
-    /**
-     * Retrieves the valid numerical representation of the drive strength.
-     */
-    uint32_t get_strength() const { return get_value(); };
-
 };
 
 /**

--- a/include/i2c_cxx.hpp
+++ b/include/i2c_cxx.hpp
@@ -83,11 +83,6 @@ public:
         return I2CNumber(1);
     }
 #endif
-
-    /**
-     * Retrieves the valid numerical representation of the I2C number.
-     */
-    uint32_t get_num();
 };
 
 /**
@@ -101,11 +96,6 @@ public:
      *
      */
     explicit I2CAddress(uint8_t addr);
-
-    /**
-     * Retrieves the valid numerical representation of the I2C adress.
-     */
-    uint8_t get_addr();
 };
 
 /**

--- a/include/spi_cxx.hpp
+++ b/include/spi_cxx.hpp
@@ -64,18 +64,6 @@ public:
             throw SPIException(spi_num_check_result);
         }
     }
-
-    /**
-     * @brief Return the raw value of the SPI host.
-     *
-     * This should only be used when calling driver and other interfaces which don't support the C++ class.
-     *
-     * @return the raw value of the SPI host.
-     */
-    uint32_t get_spi_num() const
-    {
-        return get_value();
-    }
 };
 
 /**
@@ -134,17 +122,6 @@ public:
      * @brief Create a configuration where the driver allocates DMA.
      */
     static SPI_DMAConfig AUTO();
-
-    /**
-     * @brief Return the raw value of the DMA configuration.
-     *
-     * This should only be used when calling driver and other interfaces which don't support the C++ class.
-     *
-     * @return the raw value of the DMA configuration.
-     */
-    uint32_t get_num() const {
-        return get_value();
-    }
 };
 
 }

--- a/include/system_cxx.hpp
+++ b/include/system_cxx.hpp
@@ -31,8 +31,9 @@ class StrongValue {
 protected:
     constexpr StrongValue(ValueT value_arg) : value(value_arg) { }
 
-    ValueT get_value() const {
-        return value;
+    template<typename RawType = ValueT>
+    RawType get_value() const {
+        return static_cast<RawType>(value);
     }
 
 private:

--- a/private_include/spi_host_private_cxx.hpp
+++ b/private_include/spi_host_private_cxx.hpp
@@ -23,17 +23,6 @@ namespace idf {
 
 #define SPI_CHECK_THROW(err) CHECK_THROW_SPECIFIC((err), SPIException)
 
-namespace {
-
-/**
- * @brief Convenience method to convert a SPINum object into the driver type. Avoids long static casts.
- */
-spi_host_device_t spi_num_to_driver_type(const SPINum &num) noexcept {
-    return static_cast<spi_host_device_t>(num.get_spi_num());
-}
-
-}
-
 /**
  * This class wraps closely around the SPI master device driver functions.
  * It is used to hide the implementation, in particular the dependencies on the driver and HAL layer headers.
@@ -55,11 +44,11 @@ public:
     {
         spi_device_interface_config_t dev_config = {};
         dev_config.clock_speed_hz = frequency.get_value();
-        dev_config.spics_io_num = cs.get_num();
+        dev_config.spics_io_num = cs.get_value();
         dev_config.pre_cb = pr_cb;
         dev_config.post_cb = post_cb;
         dev_config.queue_size = q_size.get_size();
-        SPI_CHECK_THROW(spi_bus_add_device(spi_num_to_driver_type(spi_host), &dev_config, &handle));
+        SPI_CHECK_THROW(spi_bus_add_device(spi_host.get_value<spi_host_device_t>(), &dev_config, &handle));
     }
 
     SPIDeviceHandle(const SPIDeviceHandle &other) = delete;

--- a/spi_host_cxx.cpp
+++ b/spi_host_cxx.cpp
@@ -32,14 +32,14 @@ SPIMaster::SPIMaster(SPINum host,
     : spi_host(host)
 {
     spi_bus_config_t bus_config = {};
-    bus_config.mosi_io_num = mosi.get_num();
-    bus_config.miso_io_num = miso.get_num();
-    bus_config.sclk_io_num = sclk.get_num();
+    bus_config.mosi_io_num = mosi.get_value();
+    bus_config.miso_io_num = miso.get_value();
+    bus_config.sclk_io_num = sclk.get_value();
     bus_config.quadwp_io_num = -1;
     bus_config.quadhd_io_num = -1;
     bus_config.max_transfer_sz = transfer_size.get_value();
 
-    SPI_CHECK_THROW(spi_bus_initialize(spi_num_to_driver_type(spi_host), &bus_config, dma_config.get_num()));
+    SPI_CHECK_THROW(spi_bus_initialize(spi_host.get_value<spi_host_device_t>(), &bus_config, dma_config.get_value()));
 }
 
 SPIMaster::SPIMaster(SPINum host,
@@ -53,19 +53,19 @@ SPIMaster::SPIMaster(SPINum host,
     : spi_host(host)
 {
     spi_bus_config_t bus_config = {};
-    bus_config.mosi_io_num = mosi.get_num();
-    bus_config.miso_io_num = miso.get_num();
-    bus_config.sclk_io_num = sclk.get_num();
-    bus_config.quadwp_io_num = qspiwp.get_num();
-    bus_config.quadhd_io_num = qspihd.get_num();
+    bus_config.mosi_io_num = mosi.get_value();
+    bus_config.miso_io_num = miso.get_value();
+    bus_config.sclk_io_num = sclk.get_value();
+    bus_config.quadwp_io_num = qspiwp.get_value();
+    bus_config.quadhd_io_num = qspihd.get_value();
     bus_config.max_transfer_sz = transfer_size.get_value();
 
-    SPI_CHECK_THROW(spi_bus_initialize(spi_num_to_driver_type(spi_host), &bus_config, dma_config.get_num()));
+    SPI_CHECK_THROW(spi_bus_initialize(spi_host.get_value<spi_host_device_t>(), &bus_config, dma_config.get_value()));
 }
 
 SPIMaster::~SPIMaster()
 {
-    spi_bus_free(spi_num_to_driver_type(spi_host));
+    spi_bus_free(spi_host.get_value<spi_host_device_t>());
 }
 
 shared_ptr<SPIDevice> SPIMaster::create_dev(CS cs, Frequency frequency)


### PR DESCRIPTION
- remove all wrapper functions (e.g, get_num, get_level, etc...) from the associated classes
- use inherited get_value() method throughout the code
- remove specific conversion functions and use generic template function instead