### PR TITLE
ci: added nightly build job

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,6 +1,10 @@
 name: Build Examples
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *' # Once per day at midnight   
+  pull_request:
+    - types: [opened, reopened, synchronize]
 
 jobs:
   host_test:

--- a/.github/workflows/test_target.yml
+++ b/.github/workflows/test_target.yml
@@ -1,6 +1,10 @@
 name: Target test
 
-on: [push, pull_request]
+on: 
+  schedule:
+    - cron: '0 0 * * *' # Once per day at midnight   
+  pull_request:
+    - types: [opened, reopened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a nightly build job to check if esp-idf-cxx is still working with the latest version of ESP-IDF.