### PR TITLE
fix: ci workflows on.pull_request - fixed parameters

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *' # Once per day at midnight   
   pull_request:
-    - types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   host_test:

--- a/.github/workflows/test_target.yml
+++ b/.github/workflows/test_target.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *' # Once per day at midnight   
   pull_request:
-    - types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
The workflows changed in https://github.com/espressif/esp-idf-cxx/pull/14 have a flaw which make them fail at parsing level. This PR fixes them. 