### PR TITLE
Update cmake version, add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.md,*.rst}]
+trim_trailing_whitespace = false
+
+[*.py]
+max_line_length = 119
+
+[{*.cmake,CMakeLists.txt}]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+[{*.sh,*.yml,*.yaml}]
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 Contributions to ESP-IDF-CXX - fixing bugs, adding features, adding documentation - are welcome! We accept contributions via Github Pull Requests.
 
-Currently, we use the same contribution guidelines as ESP-IDF itself as basis. Please see the [ESP-IDF Contributions Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/contribute/index.html) for more information. However, the workflow is quite simplified, we only use github for collaboration. Furthermore, we use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for commits.
+Currently, we use the same contribution guidelines as ESP-IDF itself as basis. Please refer to the [ESP-IDF Contributions Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/contribute/index.html) for more information. However, the workflow is quite simplified, we only use github for collaboration. Furthermore, we use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for commits. There is an [editorconfig file](.editorconfig) to setup your editor or IDE with some basic options (tab-style, line ending, etc.).
 
 Please also consider the legal part: You will be required to sign the [Contributor Agreement](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/contribute/contributor-agreement.html) for any Pull Request.

--- a/examples/blink_cxx/CMakeLists.txt
+++ b/examples/blink_cxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/examples/esp_event_async_cxx/CMakeLists.txt
+++ b/examples/esp_event_async_cxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/examples/esp_timer_cxx/CMakeLists.txt
+++ b/examples/esp_timer_cxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/examples/simple_i2c_rw_example/CMakeLists.txt
+++ b/examples/simple_i2c_rw_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/examples/simple_spi_rw_example/CMakeLists.txt
+++ b/examples/simple_spi_rw_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/host_test/esp_timer/CMakeLists.txt
+++ b/host_test/esp_timer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/host_test/gpio/CMakeLists.txt
+++ b/host_test/gpio/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/host_test/i2c/CMakeLists.txt
+++ b/host_test/i2c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/host_test/spi/CMakeLists.txt
+++ b/host_test/spi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/host_test/system/CMakeLists.txt
+++ b/host_test/system/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)

--- a/test_apps/esp_event/CMakeLists.txt
+++ b/test_apps/esp_event/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is the project CMakeLists.txt file for the test subproject
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 set(COMPONENTS main)
 

--- a/test_apps/esp_timer/CMakeLists.txt
+++ b/test_apps/esp_timer/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is the project CMakeLists.txt file for the test subproject
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 set(COMPONENTS main)
 


### PR DESCRIPTION
This MR updates the CMake version to 3.16 to match the IDF CMake requirements and additionally adds an editorconfig file (`.editorconfig`).

CMake version 3.16 is the version we also require in IDF v5.0. The editorconfig file is very similar to the one used in IDF.