### PR TITLE
fix: added pthread dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT ${target} STREQUAL "linux")
     list(APPEND srcs
         "esp_event_api.cpp"
         "esp_event_cxx.cpp")
-    list(APPEND requires "esp_event")
+    list(APPEND requires "esp_event" "pthread")
 endif()
 
 idf_component_register(SRCS ${srcs}


### PR DESCRIPTION
POSIX semaphores have been introduced to IDF recently. This means that libstdc++ requires `semaphore.h`, located in the `pthread` IDF component and is the reason of the recent build failures.

This MR adds `pthread` as a private requirement to ESP-IDF-C++ to fix this issue.