### PR TITLE
Provide configuration for all currently available targets

### DIFF
--- a/examples/simple_i2c_rw_example/README.md
+++ b/examples/simple_i2c_rw_example/README.md
@@ -2,7 +2,7 @@
 
 (See the README.md file in the upper level 'examples' directory for more information about examples.)
 
-This example demonstrates usage of C++ exceptions in ESP-IDF. It is the C++ equivalent to the [I2C Simple Example](../../../peripherals/i2c/i2c_simple/) which is written in C.
+This example demonstrates usage of C++ exceptions in ESP-IDF. It is the C++ equivalent to the [I2C Simple Example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/i2c/i2c_simple/) which is written in C.
 
 In this example, the `sdkconfig.defaults` file sets the `CONFIG_COMPILER_CXX_EXCEPTIONS` option. This enables both compile time support (`-fexceptions` compiler flag) and run-time support for C++ exception handling. This is necessary for the C++ I2C API.
 
@@ -57,4 +57,3 @@ If something went wrong:
 I2C Exception with error: ESP_FAIL (-1)
 Couldn't read sensor!
 ```
-

--- a/examples/simple_i2c_rw_example/main/Kconfig.projbuild
+++ b/examples/simple_i2c_rw_example/main/Kconfig.projbuild
@@ -2,14 +2,16 @@ menu "Example Configuration"
 
     config I2C_MASTER_SCL
         int "SCL GPIO Num"
-        default 6 if IDF_TARGET_ESP32C3
+        default 6 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        default 5 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32H2
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
         help
             GPIO number for I2C Master clock line.
 
     config I2C_MASTER_SDA
         int "SDA GPIO Num"
-        default 5 if IDF_TARGET_ESP32C3
+        default 5 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        default 4 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32H2
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
         help
             GPIO number for I2C Master data line.

--- a/examples/simple_spi_rw_example/main/Kconfig.projbuild
+++ b/examples/simple_spi_rw_example/main/Kconfig.projbuild
@@ -1,0 +1,44 @@
+menu "Example Configuration"
+
+    config SPI_NUM
+        int "SPI Num"
+        default 1 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32H2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        default 2 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        help
+            The number of the chip's SPI peripheral.
+
+    config SPI_CS
+        int "CS GPIO Num"
+        default 10 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32H2
+        default 23 if IDF_TARGET_ESP32
+        default 4 if IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        help
+            GPIO number for SPI CS line.
+
+    config SPI_MOSI
+        int "MOSI GPIO Num"
+        default 11 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32H2
+        default 25 if IDF_TARGET_ESP32
+        default 5 if IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        help
+            GPIO number for SPI MOSI line.
+
+    config SPI_MISO
+        int "MISO GPIO Num"
+        default 0 if IDF_TARGET_ESP32C6
+        default 12 if IDF_TARGET_ESP32H2
+        default 26 if IDF_TARGET_ESP32
+        default 6 if IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        help
+            GPIO number for SPI MISO line.
+
+    config SPI_SCLK
+        int "SCLK GPIO Num"
+        default 1 if IDF_TARGET_ESP32C6
+        default 22 if IDF_TARGET_ESP32H2
+        default 27 if IDF_TARGET_ESP32
+        default 7 if IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2
+        help
+            GPIO number for SPI SCLK line.
+
+endmenu

--- a/examples/simple_spi_rw_example/main/simple_spi_rw_example.cpp
+++ b/examples/simple_spi_rw_example/main/simple_spi_rw_example.cpp
@@ -12,38 +12,36 @@
  * CONDITIONS OF ANY KIND, either express or implied.
 */
 
-#include <iostream>
+#include "sdkconfig.h"
 #include <thread>
 #include "spi_host_cxx.hpp"
 
 using namespace std;
 using namespace idf;
 
-static const GPIONum NSS(23);
 static const uint8_t READ_FLAG = 0x80;
 static const uint8_t MPU9250_WHO_AM_I_REG_ADDR = 0x75;
 
+namespace {
+static const MOSI MOSI_PIN(CONFIG_SPI_MOSI);
+static const MISO MISO_PIN(CONFIG_SPI_MISO);
+static const SCLK SCLK_PIN(CONFIG_SPI_SCLK);
+static const CS     CS_PIN(CONFIG_SPI_CS);
+}
+
 extern "C" void app_main(void)
 {
-    try {
+        SPIMaster master(SPINum(1),
+                MOSI_PIN,
+                MISO_PIN,
+                SCLK_PIN);
 
-        SPIMaster master(SPINum(2),
-                MOSI(25),
-                MISO(26),
-                SCLK(27));
-
-        shared_ptr<SPIDevice> spi_dev = master.create_dev(CS(NSS.get_value()), Frequency::MHz(1));
+        shared_ptr<SPIDevice> spi_dev = master.create_dev(CS_PIN, Frequency::MHz(1));
 
         vector<uint8_t> write_data = {MPU9250_WHO_AM_I_REG_ADDR | READ_FLAG, 0x00};
         vector<uint8_t> result = spi_dev->transfer(write_data).get();
 
-        cout << "Result of WHO_AM_I register: 0x";
-        printf("%02X", result[1]);
-        cout << endl;
+        printf("Result of WHO_AM_I register: 0x%02X\n", result[1]);
 
         this_thread::sleep_for(std::chrono::seconds(2));
-
-    } catch (const SPIException &e) {
-        cout << "Couldn't read SPI!" << endl;
-    }
 }

--- a/gpio_cxx.cpp
+++ b/gpio_cxx.cpp
@@ -27,6 +27,10 @@ constexpr std::array<uint32_t, 4> INVALID_GPIOS = {22, 23, 24, 25};
 constexpr std::array<uint32_t, 0> INVALID_GPIOS = {};
 #elif CONFIG_IDF_TARGET_ESP32C2
 constexpr std::array<uint32_t, 0> INVALID_GPIOS = {};
+#elif CONFIG_IDF_TARGET_ESP32C6
+constexpr std::array<uint32_t, 0> INVALID_GPIOS = {};
+#elif CONFIG_IDF_TARGET_ESP32H2
+constexpr std::array<uint32_t, 0> INVALID_GPIOS = {};
 #else
 #error "No GPIOs defined for the current target"
 #endif

--- a/i2c_cxx.cpp
+++ b/i2c_cxx.cpp
@@ -21,7 +21,6 @@ namespace idf {
 #if SOC_I2C_NUM >= 2
 static_assert(I2C_NUM_1 == 1, "I2C_NUM_1 must be equal to 1");
 #endif // SOC_I2C_NUM >= 2
-static_assert(I2C_NUM_MAX == SOC_I2C_NUM, "I2C_NUM_MAX must be equal to SOC_I2C_NUM");
 
 esp_err_t check_i2c_num(uint32_t i2c_num) noexcept
 {


### PR DESCRIPTION
This MR adds example configurations for all currently available targets. Before, builds would fail on some targets due to these missing configurations.

This MR also fixes a wrong link in the documentation.

closes #23 