### PR TITLE
Fix for esp32c6

### DIFF
--- a/i2c_cxx.cpp
+++ b/i2c_cxx.cpp
@@ -18,9 +18,9 @@ namespace idf {
 /**
  * I2C bus are defined in the header files, let's check that the values are correct
  */
-#if SOC_I2C_NUM >= 2
+#if SOC_HP_I2C_NUM >= 2
 static_assert(I2C_NUM_1 == 1, "I2C_NUM_1 must be equal to 1");
-#endif // SOC_I2C_NUM >= 2
+#endif // SOC_HP_I2C_NUM >= 2
 
 esp_err_t check_i2c_num(uint32_t i2c_num) noexcept
 {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

A minor fix so esp-idf-cxx can compile correctly for esp32c6 (and maybe other?)

i2c_cxx incorrectly assumed that `I2C_NUM_1` would exist if `SOC_I2C_NUM >= 2`. But that's not the case when the device has 1 HP i2c and 1 LP i2c.

This changes i2c_cxx to look at only the HP `SOC_HP_I2C_NUM` instead

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

My own code compiles now 😄 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
